### PR TITLE
fix: link to "Using .NET Libraries" in JSON section

### DIFF
--- a/reference/libraries/json.md
+++ b/reference/libraries/json.md
@@ -3,7 +3,7 @@
 Instead of operating on a JSON object directly, in VL by default the JSON is converted to an XElement which can be easily inspected and modified. Vice versa, an XElement can always be converted to JSON.
 
 > [!NOTE]
-> If in an advanced use case you find yourself in a situation where this conversion from JSON to XElement is not feasible, you can still operate on JSON directly by referencing a library like [JSON.NET](https://www.newtonsoft.com/json), as described in [Using .NET Libraries](using-net-libraries.md).
+> If in an advanced use case you find yourself in a situation where this conversion from JSON to XElement is not feasible, you can still operate on JSON directly by referencing a library like [JSON.NET](https://www.newtonsoft.com/json), as described in [Using .NET Libraries](../extending/using-net-libraries.md).
 
 ## Loading a JSON file
 


### PR DESCRIPTION
**To reviewers**: Please also add a [CONTRIBUTING.md](https://mozillascience.github.io/working-open-workshop/contributing/). Given that we would be suggestion the gray book going forward, I think contributing to it should be as easy as possible. 

I found local writing process to be rather cumbersome. Any change that I made required me to manually rebuild using docfx, and the build-serve command just acted like a file server for me. Also because the Algolia search is so handy, I was continuously using it and later realised that it is opening https://thegraybook.vvvv.org/ and not my localhost. The lack of TOC sidebar and header links in a local env makes navigation difficult for me.

My experience with [gitbook.io](https://gitbook.io) had been quite good. I'm not necessarily suggesting to migrate to it, but rather provide a similar experience with docfx locally.  

A combination of `watchexec -qrc --workdir $PWD -- ./build.bat` and `live-server` worked for me. [[watchexec](https://watchexec.github.io/), [live-server](https://www.npmjs.com/package/live-server)]