### PR TITLE
fix: Counter example in Writing Nodes section

### DIFF
--- a/reference/extending/writing-nodes.md
+++ b/reference/extending/writing-nodes.md
@@ -272,18 +272,20 @@ By default all its public members will be used as its fragments. The attribute p
 
 ```csharp
 [ProcessNode]
-public class Counter
+public class MyCounter
 {
-    public Counter(int initialValue)
+    int value;
+
+    public MyCounter(int initialValue)
     {
-        Value = initialValue;
+        value = initialValue;
     }
 
-    public void Increment() => _counter++;
+    public int Update() => value;
 
-    public void Decrement() => _counter--;
+    public void Increment() => value++;
 
-    public int Value { get; set; }
+    public void Decrement() => value--;
 }
 ```
 


### PR DESCRIPTION
The current Counter example under "Process nodes" subheading doesn't compile because of errors. So this PR fixes that.

Sidenote: I am wondering if we should eliminate syntactic sugars in these examples. As someone coming other programming language may not be familiar with `=>` shorthand.